### PR TITLE
Deprecate --only-merge and use always ReadTools for download

### DIFF
--- a/bin/distmap
+++ b/bin/distmap
@@ -103,7 +103,7 @@ GetOptions(
 	"trim-args"				=> \$trim_args,
 	"only-map" 				=> \$only_map,
 	"only-hdfs-download" 			=> \$only_hdfs_download,
-	"only-merge" 				=> \$only_merging,
+	"only-merge" 				=> \$only_merging, # DEPRECATED
 	"only-delete-temp" 			=> \$only_delete_temp,
 	"only-download-trimmed-reads"		=> \$only_download_reads,
 	"reference-index-archive=s"         	=> \$refindex_archive,
@@ -183,7 +183,7 @@ if($verbose) {
 	print STDERR "  (DEPRECATED) only trim reads:\t$only_trim\n";
 	print STDERR "  only mapping reads:\t$only_map\n";
 	print STDERR "  only hdfs download:\t$only_hdfs_download\n";
-	print STDERR "  only merging the hadoop mapping output files :\t$only_merging\n";
+	print STDERR "  (DEPRECATED) only merging the hadoop mapping output files :\t$only_merging\n";
 	print STDERR "  only delete temperory files and folders:\t$only_delete_temp\n";
 	print STDERR "  hadoop home:\t$hadoop_home\n";
 	print STDERR "  mapper name:\t@mapper\n";
@@ -592,17 +592,13 @@ data in Hadoop manually.
 
 =item B<--only-hdfs-download>
 
- Step5: This option assume that mapping already done on cluster and files will be downloaded
- from cluster to local output directory.
-
-=item B<--only-merge>
-
- Step6: This option assume that data already in local directory from HDFS
- and now will be merged and create a single SAM or BAM output file.
+Step5: This option assume that mapping already done on cluster and files will be downloaded
+and merged from the cluster to the local output directory using ReadTools, generating a
+sorted SAM/BAM file (see B<--output-format>)
 
 =item B<--only-delete-temp>
 
- Step7: This is the last step of piepline. This option will delete the
+ Step6: This is the last step of piepline. This option will delete the
  mapping data from HDFS file system as well as from local temp directory.
 
 =item B<--trim-args> "I<ARGS>"
@@ -671,6 +667,11 @@ EXAMPLE:
 Arguments still in use, but that might disappear in the following version.
 
 =over 4
+
+=item B<--only-merge>
+
+This option would launch Step5 in the same way as B<--only-hdfs-download>.
+Next version will remove this option in favor of B<--only-hdfs-download>
 
 =item B<--no-trim>
 

--- a/lib/perl5/site_perl/DataDownload.pm
+++ b/lib/perl5/site_perl/DataDownload.pm
@@ -9,6 +9,7 @@ use File::Basename;
 
 
 sub new {
+	die("OBSOLETE: DataDownload::new shouldn't be called. Use DataDownloadAnMerge instead");
 	my $class=shift;
 	my $self = {};
 	bless $self, $class;
@@ -17,7 +18,7 @@ sub new {
 
 
 sub start {
-
+	die("OBSOLETE: DataDownload::start shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict) = @_;
 
     print STDERR "\n\n";
@@ -47,6 +48,7 @@ sub start {
 #
 
 sub paired_end_data {
+	die("OBSOLETE: DataDownload::paired_end_data shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict) = @_;
 
     $args_dict->{"read_folder"} = "fastq_paired_end";
@@ -110,6 +112,7 @@ sub paired_end_data {
 
 
 sub single_end_data {
+	die("OBSOLETE: DataDownload::single_end_data shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict) = @_;
 
     $args_dict->{"read_folder"} = "fastq_single_end";
@@ -186,6 +189,7 @@ sub single_end_data {
 
 
 sub get_file_list {
+	die("OBSOLETE: DataDownload::get_file_list shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$dir) = @_;
     opendir(DIR, $dir) || die("Cannot open directory");
     my @files= readdir(DIR);

--- a/lib/perl5/site_perl/DataMerge.pm
+++ b/lib/perl5/site_perl/DataMerge.pm
@@ -12,6 +12,7 @@ use Cwd 'abs_path';
 
 
 sub new {
+	die("OBSOLETE: DataMerge::new shouldn't be called. Use DataDownloadAnMerge instead");
 	my $class=shift;
 	my $self = {};
 	bless $self, $class;
@@ -20,6 +21,7 @@ sub new {
 
 
 sub start {
+	die("OBSOLETE: DataMerge::start shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict) = @_;
 
     print STDERR "=======================================================================\n";
@@ -48,6 +50,7 @@ sub start {
 
 
 sub compare_fastq_bam_reads {
+	die("OBSOLETE: DataMerge::compare_fastq_bam_reads shouldn't be called. Use DataDownloadAnMerge instead");
 	my ($self,$args_dict,$fastq_dir,$final_output_file,$output_dir) = @_;
 
 	my $fastq_file_std = "$output_dir/fastq_count1";
@@ -201,6 +204,7 @@ sub compare_fastq_bam_reads {
 
 
 sub download_merge_trimmed_reads {
+	die("OBSOLETE: DataMerge::download_merge_trimmed_reads shouldn't be called. Use DataDownloadAnMerge instead");
 	my ($self,$args_dict) = @_;
 	my $script_current_file = abs_path($0);
 	my ( $name, $path, $extension ) = File::Basename::fileparse ( $script_current_file, '\..*' );
@@ -227,6 +231,7 @@ sub download_merge_trimmed_reads {
 
 
 sub paired_end_data {
+	die("OBSOLETE: DataMerge::paired_end_data shouldn't be called. Use DataDownloadAnMerge instead");
 	my ($self,$args_dict) = @_;
 
 	$args_dict->{"read_folder"} = "fastq_paired_end";
@@ -303,6 +308,7 @@ sub paired_end_data {
 
 
 sub single_end_data {
+	die("OBSOLETE: DataMerge::single_end_data shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict) = @_;
 
     $args_dict->{"read_folder"} = "fastq_single_end";
@@ -404,6 +410,7 @@ sub single_end_data {
 
 
 sub get_file_list {
+	die("OBSOLETE: DataMerge::get_file_list shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$dir) = @_;
     opendir(DIR, $dir) || die("Cannot open directory");
     my @files= readdir(DIR);
@@ -432,6 +439,7 @@ sub get_file_list {
 }
 
 sub bwa_output {
+	die("OBSOLETE: DataMerge::bwa_output shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict, $mapper_name) = @_;
 
     my $temp_output_folder = "$args_dict->{'output_directory'}/$args_dict->{'random_id'}/$args_dict->{'read_output_folder'}";
@@ -566,6 +574,7 @@ sub bwa_output {
 }
 
 sub tophat_output {
+	die("OBSOLETE: DataMerge::tophat_output shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict, $mapper_name) = @_;
 
     my $temp_output_folder = "$args_dict->{'output_directory'}/$args_dict->{'random_id'}/$args_dict->{'read_output_folder'}";
@@ -690,6 +699,7 @@ sub tophat_output {
 
 
 sub check_mapping_files {
+	die("OBSOLETE: DataMerge::check_mapping_files shouldn't be called. Use DataDownloadAnMerge instead");
 	my ($self,$temp_output_folder) = @_;
 
 	my $files_to_discard = {};
@@ -976,6 +986,7 @@ sub check_mapping_files {
 
 
 sub exonerate_output {
+	die("OBSOLETE: DataMerge::exonerate_output shouldn't be called. Use DataDownloadAnMerge instead");
     my ($self,$args_dict) = @_;
 
     my $temp_output_folder = "$args_dict->{'output_directory'}/$args_dict->{'random_id'}/$args_dict->{'read_output_folder'}";

--- a/lib/perl5/site_perl/Utility.pm
+++ b/lib/perl5/site_perl/Utility.pm
@@ -454,22 +454,14 @@ sub get_steps {
 		$step_hash->{5} = $mapping_object;
 	}
 
-
-    if ( $args_dict->{"only_hdfs_download"} and $args_dict->{"only_merge"} ) {
-        my $datadownloadandmerge_object = DataDownloadAndMerge->new();
-        $step_hash->{6} = $datadownloadandmerge_object;
-    }
-    else {
-        if ( $args_dict->{"only_hdfs_download"} ) {
-            my $datadownload_object = DataDownload->new();
-            $step_hash->{6} = $datadownload_object;
-        }
-        if ( $args_dict->{"only_merge"} ) {
-            my $datamerge_object = DataMerge->new();
-            $step_hash->{7} = $datamerge_object;
-        }
-    }
-
+	if ( $args_dict->{"only_hdfs_download"} or $args_dict->{"only_merge"} ) {
+		print "--only-hdfs-download now merges also the data in the same step";
+		if ( $args_dict->{"only_merge"} ) {
+			print "WARNING: --only-merge is deprecated. Use --only-hdfs-download instead";
+		}
+		my $datadownloadandmerge_object = DataDownloadAndMerge->new();
+		$step_hash->{6} = $datadownloadandmerge_object;
+	}
 
 	if ($args_dict->{"only_download_reads"}) {
 	    my $read_download_object = DownloadTrimmedRead->new();


### PR DESCRIPTION
This PR removes all possible usages of `DataDownload` and `DataMerge` in favor of `DataDownloadAndMerge`. Includes:

- Die in every method for deprecated classes
- Deprecate `--only-merge` argument, using it for the same as `--only-hdfs-download` (and log a warning if used)
- Update help for `--only-merge` and `--only-hdfs-download`

Part of #78