### PR TITLE
Obsolete download trimmed reads

### DIFF
--- a/bin/distmap
+++ b/bin/distmap
@@ -135,6 +135,7 @@ GetOptions(
 	# DEPRECATED (log warning if used?) - TODO: remove support
 	## triming
 	"no-trim"						=> \$no_trim,
+	"only-download-trimmed-reads"	=> \$only_download_reads,
 	"only-merge"					=> \$only_merging,
 	"quality-threshold=i"			=>\$qualThreshold,
 	"discard-internal-N"			=>\$discardRemainingNs,
@@ -154,7 +155,6 @@ GetOptions(
 
 
 	## TODO: undocummented options!!!
-	"only-download-trimmed-reads"	=> \$only_download_reads,
 	"mappers-exe-archive=s"			=>\$mappers_exe_archive
 
 ) or pod2usage(-msg=>"Wrong options",-verbose=>1);
@@ -733,6 +733,13 @@ Next version will remove this option in favor of B<--only-hdfs-download>
 
  This option will skip the trimming. Next version will decide if trimming
  will be performed by using B<--trim-args>
+
+=item B<--only-download-trimmed-reads>
+
+This option would download the only trimmed reads. As trimming is done on
+upload or locally with ReadTools, this option is equivalent to download
+mapped reads and convert to FASTQ or trim locally with ReadTools and
+upload in a second step.
 
 =item B<--verbose>
 

--- a/lib/perl5/site_perl/DownloadTrimmedRead.pm
+++ b/lib/perl5/site_perl/DownloadTrimmedRead.pm
@@ -13,6 +13,7 @@ use Utility;
 
 
 sub new {
+	die("OBSOLETE: DownloadTrimmedRead::new shouldn't be called.");
 	my $class=shift;
 	my $self = {};
 	bless $self, $class;
@@ -21,6 +22,7 @@ sub new {
 
 
 sub start {
+	die("OBSOLETE: DownloadTrimmedRead::start shouldn't be called.");
 	my ($self,$args_dict) = @_;
 
 
@@ -54,6 +56,7 @@ sub start {
 
 
 sub paired_end_trimming {
+	die("OBSOLETE: DownloadTrimmedRead::paired_end_trimming shouldn't be called.");
 	my ($self,$args_dict) = @_;
 
 	$args_dict->{"read_folder"} = "fastq_paired_end";
@@ -84,6 +87,7 @@ sub paired_end_trimming {
 
 
 sub single_end_trimming {
+	die("OBSOLETE: DownloadTrimmedRead::single_end_trimming shouldn't be called.");
 	my ($self,$args_dict) = @_;
 
 	$args_dict->{"read_folder"} = "fastq_single_end";
@@ -112,6 +116,7 @@ sub single_end_trimming {
 
 
 sub get_file_list {
+	die("OBSOLETE: DownloadTrimmedRead::get_file_list shouldn't be called.");
 	my ($self,$dir) = @_;
 	opendir(DIR, $dir) || die("Cannot open directory");
 	my @files= readdir(DIR);
@@ -132,6 +137,7 @@ sub get_file_list {
 
 
 sub download_merge_trimmed_reads {
+	die("OBSOLETE: DownloadTrimmedRead::download_merge_trimmed_reads shouldn't be called.");
 	my ($self,$args_dict) = @_;
 	my $script_current_file = abs_path($0);
 	my ( $name, $path, $extension ) = File::Basename::fileparse ( $script_current_file, '\..*' );
@@ -178,6 +184,7 @@ sub download_merge_trimmed_reads {
 
 
 sub merge_trimmed_reads {
+	die("OBSOLETE: DownloadTrimmedRead::merge_trimmed_reads shouldn't be called.");
     my ($self,$args_dict) = @_;
 
     my $temp_output_folder = "$args_dict->{'output_directory'}/$args_dict->{'local_home'}/$args_dict->{'read_folder'}"."_trimming";
@@ -251,6 +258,7 @@ sub merge_trimmed_reads {
 
 
 sub write_fastq {
+	die("OBSOLETE: DownloadTrimmedRead::write_fastq shouldn't be called.");
 	my ($self,$ofh1,$ofh2,$fh) = @_;
 
 	my $read_name = "";
@@ -311,6 +319,7 @@ sub write_fastq {
 }
 
 	sub getofhcreater{
+		die("OBSOLETE: DownloadTrimmedRead::getofhcreater shouldn't be called.");
 		my $self=shift;
 		my $nozip=shift;
 		my $outfile=shift;
@@ -329,6 +338,7 @@ sub write_fastq {
 
 
 sub check_mapping_files {
+	die("OBSOLETE: DownloadTrimmedRead::check_mapping_files shouldn't be called.");
 	my ($self,$temp_output_folder) = @_;
 
 	my $files_to_discard = {};

--- a/lib/perl5/site_perl/DownloadTrimmedRead.pm
+++ b/lib/perl5/site_perl/DownloadTrimmedRead.pm
@@ -189,7 +189,6 @@ sub merge_trimmed_reads {
 
     my $temp_output_folder = "$args_dict->{'output_directory'}/$args_dict->{'local_home'}/$args_dict->{'read_folder'}"."_trimming";
 
-    my $picard_mergesamfiles_jar = $args_dict->{"picard_mergesamfiles_jar"};
     my $output_dir = $args_dict->{"output_directory"};
     my $output_format = $args_dict->{"output_format"};
 

--- a/lib/perl5/site_perl/Utility.pm
+++ b/lib/perl5/site_perl/Utility.pm
@@ -341,7 +341,7 @@ sub check_mapper {
 
 	#$args_dict->{"mapper_args"} = $mapper_args;
 
-	if ($args_dict->{"mapper_args"} =~ //) {
+	if ($args_dict->{"mapper_args"} =~ // ) {
 
 	}
 
@@ -438,8 +438,9 @@ sub get_steps {
 	}
 
 	if ($args_dict->{"only_download_reads"}) {
-	    my $read_download_object = DownloadTrimmedRead->new();
-	    $step_hash->{8} = $read_download_object;
+		die("OBSOLETE: --only-download-trimmed-reads is not supported anymore (and has not work for a while). Use ReadTools for trimming if you need the raw reads, or convert output from mapping using Picard/ReadTools");
+	    # my $read_download_object = DownloadTrimmedRead->new();
+	    # $step_hash->{8} = $read_download_object;
 
 	}
 	if ($args_dict->{"only_delete_temp"}) {


### PR DESCRIPTION
Removes support for download trimmed reads from the cluster:

-  `die` when calling any method form `DownloadTrimmedRead`
- `die` if utility detects the `--only-download-trimmed-reads` argument (fixes #64)
- Remove unused picard.jar in a method from `DownloadTrimmedRead` (part of #78)
- Update documentation for `--only-download-trimmed-reads`